### PR TITLE
#3957 Fixed narrator and tab order on tree page

### DIFF
--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -131,24 +131,27 @@ data-server-root="{{server_root}}"
                 {% endfor %}
                 </ul>
               </div>
-              <div id="file_size" class="pull-right sort_button">
-                  <button type="button" class="btn btn-xs btn-default sort-action" id="file-size" aria-label="{% trans %}Sort by file size{% endtrans %}">
-                      {% trans %}File size{% endtrans %}
-                      <i class="fa"></i>
+              <div id="sort_buttons" class="pull-right">
+                <div id="sort_name" class="sort_button">
+                  <button type="button" class="btn btn-xs btn-default sort-action" id="sort-name" aria-label="{% trans %}Sort by name{% endtrans %}">
+                        {% trans %}Name{% endtrans %}
+                        <i class="fa fa-arrow-down"></i>
                   </button>
+                </div>
+                <div id="last_modified" class="sort_button">
+                    <button type="button" class="btn btn-xs btn-default sort-action" id="last-modified" aria-label="{% trans %}Sort by last modified{% endtrans %}">
+                        {% trans %}Last Modified{% endtrans %}
+                        <i class="fa"></i>
+                    </button>
+                </div>
+                <div id="file_size" class="sort_button">
+                    <button type="button" class="btn btn-xs btn-default sort-action" id="file-size" aria-label="{% trans %}Sort by file size{% endtrans %}">
+                        {% trans %}File size{% endtrans %}
+                        <i class="fa"></i>
+                    </button>
+                </div>
               </div>
-              <div id="last_modified" class="pull-right sort_button">
-                  <button type="button" class="btn btn-xs btn-default sort-action" id="last-modified" aria-label="{% trans %}Sort by last modified{% endtrans %}">
-                      {% trans %}Last Modified{% endtrans %}
-                      <i class="fa"></i>
-                  </button>
-              </div>
-              <div id="sort_name" class="pull-right sort_button">
-                <button type="button" class="btn btn-xs btn-default sort-action" id="sort-name" aria-label="{% trans %}Sort by name{% endtrans %}">
-                      {% trans %}Name{% endtrans %}
-                      <i class="fa fa-arrow-down"></i>
-                </button>
-              </div>
+
             </div>
           </div>
         </div>


### PR DESCRIPTION
Surrounded the existing buttons with a div class pull right and changed the ordering of the code to match the existing visual order